### PR TITLE
Adding tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>
                 <executions>
@@ -97,6 +102,12 @@
             <groupId>com.manorrock.yaml</groupId>
             <artifactId>yaml</artifactId>
             <version>20.11.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <developers>

--- a/src/main/java/com/manorrock/parrot/Parrot.java
+++ b/src/main/java/com/manorrock/parrot/Parrot.java
@@ -137,7 +137,7 @@ public class Parrot {
      *
      * @param file the file to process.
      */
-    private void processFile(File file) {
+    void processFile(File file) {
         System.out.println("--- Processing file: " + file);
         ParrotContext context = new ParrotContext();
         if (runsOn != null) {
@@ -145,7 +145,7 @@ public class Parrot {
         }
         context.setCurrentFile(file);
         context.getSnippets().addAll(loadFile(file));
-        context.setOutputFilename(getRelativeFilename(file).replaceAll("/", "_").replaceAll("\\.", "_") + ".yml");
+        context.setOutputFilename(generateOutputFilename(file));
         Workflow workflow = generateWorkflow(context);
         StringWriter stringWriter = new StringWriter();
         try {
@@ -167,6 +167,10 @@ public class Parrot {
         } catch (IOException ioe) {
             ioe.printStackTrace();
         }
+    }
+
+    String generateOutputFilename(File file) {
+        return getRelativeFilename(file).replaceAll("/", "_").replaceAll("\\.", "_") + ".yml";
     }
 
     /**
@@ -560,5 +564,21 @@ public class Parrot {
         if (context.getSnippetStack().isEmpty()) {
             context.getWorkflow().setName(name);
         }
+    }
+
+    public File getBaseDirectory() {
+        return baseDirectory;
+    }
+
+    public void setBaseDirectory(File baseDirectory) {
+        this.baseDirectory = baseDirectory;
+    }
+
+    public File getOutputDirectory() {
+        return outputDirectory;
+    }
+
+    public void setOutputDirectory(File outputDirectory) {
+        this.outputDirectory = outputDirectory;
     }
 }

--- a/src/test/java/com/manorrock/parrot/ParrotTest.java
+++ b/src/test/java/com/manorrock/parrot/ParrotTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2002-2021, Manorrock.com. All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *      1. Redistributions of source code must retain the above copyright
+ *         notice, this list of conditions and the following disclaimer.
+ *
+ *      2. Redistributions in binary form must reproduce the above copyright
+ *         notice, this list of conditions and the following disclaimer in the
+ *         documentation and/or other materials provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.manorrock.parrot;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests Workflow Generator.
+ */
+public class ParrotTest {
+
+    private static Parrot gwg;
+
+    @BeforeAll
+    static void init() {
+        gwg = new Parrot();
+        gwg.setBaseDirectory(new File("src/test/resources"));
+        gwg.setOutputDirectory(new File("target"));
+    }
+
+    @Test
+    void generateEmptyReadme() throws IOException {
+        File inputFile = new File("src/test/resources/empty_README.md");
+        String outputFilename = gwg.generateOutputFilename(inputFile);
+
+        // Generates the workflow
+        gwg.processFile(inputFile);
+
+        // Checks if the workflow is correct
+        Path testWorkflow = gwg.getBaseDirectory().toPath().resolve(outputFilename);
+        Path generatedWorkflow = gwg.getOutputDirectory().toPath().resolve(outputFilename);
+        assertEquals(-1l, Files.mismatch(testWorkflow, generatedWorkflow));
+    }
+
+    @Test
+    void generateReadme() throws IOException {
+        File inputFile = new File("src/test/resources/README.md");
+        String outputFilename = gwg.generateOutputFilename(inputFile);
+
+        // Generates the workflow
+        gwg.processFile(inputFile);
+
+        // Checks if the workflow is correct
+        Path testWorkflow = gwg.getBaseDirectory().toPath().resolve(outputFilename);
+        Path generatedWorkflow = gwg.getOutputDirectory().toPath().resolve(outputFilename);
+        assertEquals(-1l, Files.mismatch(testWorkflow, generatedWorkflow));
+    }
+
+    @Test
+    void generateReadmeWithInclude() throws IOException {
+        File inputFile = new File("src/test/resources/include_README.md");
+        String outputFilename = gwg.generateOutputFilename(inputFile);
+
+        // Generates the workflow
+        gwg.processFile(inputFile);
+
+        // Checks if the workflow is correct
+        Path testWorkflow = gwg.getBaseDirectory().toPath().resolve(outputFilename);
+        Path generatedWorkflow = gwg.getOutputDirectory().toPath().resolve(outputFilename);
+        assertEquals(-1l, Files.mismatch(testWorkflow, generatedWorkflow));
+    }
+}

--- a/src/test/resources/README.md
+++ b/src/test/resources/README.md
@@ -1,0 +1,48 @@
+# README
+
+Text does not appear in the workflow.
+
+## CRON
+
+This generates a cron entry in the workflow:
+
+<!-- workflow.cron(0 1 * * 2) -->
+
+## Skip
+
+What's inside the skip is not added to the workflow:
+
+<!-- workflow.skip() 
+This is workflow.skip() 
+-->
+
+## Run
+
+What's inside the run method does not appear in the workflow but is executed
+
+<!-- workflow.run() 
+This is workflow.run() 
+-->
+
+## Direct Only
+
+Appears in the workflow as is
+
+<!-- workflow.directOnly()
+This is workflow.directOnly() 
+  -->
+
+## Include
+
+This includes the file into the generated workflow
+
+<!-- workflow.include(./to_be_included.md) -->
+
+## Shell
+
+Anything in a shell is added to the workflow:
+
+```shell
+  This is a shell
+```
+

--- a/src/test/resources/README_md.yml
+++ b/src/test/resources/README_md.yml
@@ -1,0 +1,19 @@
+on: 
+  schedule: 
+    - cron: '0 1 * * 2'
+  workflow_dispatch: 
+
+name: 'README.md'
+jobs: 
+  validate: 
+    runs-on: 'ubuntu-latest'
+    steps: 
+      - uses: 'azure/login@v1'
+        with: 
+          allow-no-subscriptions: 'true'
+          creds: '${{ secrets.AZURE_CREDENTIALS }}'
+      - uses: 'actions/checkout@v2'
+      - run: | 
+          This is workflow.directOnly()
+          This is a shell that is included from another file
+          This is a shell

--- a/src/test/resources/empty_README_md.yml
+++ b/src/test/resources/empty_README_md.yml
@@ -1,0 +1,14 @@
+on: 
+  workflow_dispatch: 
+
+name: 'empty_README.md'
+jobs: 
+  validate: 
+    runs-on: 'ubuntu-latest'
+    steps: 
+      - uses: 'azure/login@v1'
+        with: 
+          allow-no-subscriptions: 'true'
+          creds: '${{ secrets.AZURE_CREDENTIALS }}'
+      - uses: 'actions/checkout@v2'
+      - run: |

--- a/src/test/resources/include_README.md
+++ b/src/test/resources/include_README.md
@@ -1,0 +1,10 @@
+# README with Includes
+
+This included file exists:
+
+<!-- workflow.include(./to_be_included.md) -->
+
+This one doesnt:
+
+<!-- workflow.include(./dummy.md) -->
+

--- a/src/test/resources/include_README_md.yml
+++ b/src/test/resources/include_README_md.yml
@@ -1,0 +1,15 @@
+on: 
+  workflow_dispatch: 
+
+name: 'include_README.md'
+jobs: 
+  validate: 
+    runs-on: 'ubuntu-latest'
+    steps: 
+      - uses: 'azure/login@v1'
+        with: 
+          allow-no-subscriptions: 'true'
+          creds: '${{ secrets.AZURE_CREDENTIALS }}'
+      - uses: 'actions/checkout@v2'
+      - run: | 
+          This is a shell that is included from another file

--- a/src/test/resources/to_be_included.md
+++ b/src/test/resources/to_be_included.md
@@ -1,0 +1,6 @@
+# To be included
+
+```shell
+  This is a shell that is included from another file
+```
+


### PR DESCRIPTION
Fixes #26

There are three tests:

* Generates a workflow from a totally empty README file
* Generates a workflow from a README with all sorts of actions (cron, run, shell...)
* Generates a workflow from a README including known and unknown files

The tests generate a workflow and match the generated file with the existing one (under src/test/resource)